### PR TITLE
Fix: Prevent data leakage in ML augmentation workflow

### DIFF
--- a/src/main_ml_augmented.py
+++ b/src/main_ml_augmented.py
@@ -26,37 +26,77 @@ def run_experiment_ml_rf_combined_augmented():
         print("No audio segments loaded after processing. Exiting.")
         return
 
-    # 3. Extract features (Using combined stats, with augmentation enabled)
-    # Augmentation happens *during* feature processing in this setup
-    features_df = feature_extractor.process_features_for_all_audio(
-        audio_segments, labels_numeric, feature_type="stats_cell5", augment=True
+    # Convert to numpy arrays for consistent handling if not already
+    audio_segments_np = np.array(audio_segments, dtype=object) # dtype=object for lists of varying lengths
+    labels_numeric_np = np.array(labels_numeric)
+
+    print(f"Total audio segments loaded: {len(audio_segments_np)}")
+    print(f"Total labels loaded: {len(labels_numeric_np)}")
+
+    # 3. Split data into training and testing sets BEFORE feature extraction
+    print("\nSplitting data into training and testing sets...")
+    train_segments, test_segments, train_labels, test_labels = train_test_split(
+        audio_segments_np,
+        labels_numeric_np,
+        test_size=config.TEST_SIZE,
+        random_state=config.RANDOM_STATE,
+        stratify=labels_numeric_np
     )
-    
-    X_features = np.array(features_df['feature'].tolist())
-    y_labels_numeric = np.array(features_df['class'].tolist())
+    print(f"Number of training segments: {len(train_segments)}")
+    print(f"Number of testing segments: {len(test_segments)}")
+    print(f"Number of training labels: {len(train_labels)}")
+    print(f"Number of testing labels: {len(test_labels)}")
 
-    num_features_extracted = X_features.shape[1]
-    print(f"Number of features for ML model: {num_features_extracted}")
-
-    # 4. Prepare data for ML (no one-hot for y)
-    X_ml, y_ml = train_utils.prepare_data_for_ml(X_features, y_labels_numeric)
-
-    # 5. Train/Test Split & Scale
-    # Stratify on y_ml (original numeric labels)
-    X_train_scaled, X_test_scaled, y_train, y_test = train_utils.split_and_scale_data(
-        X_ml, y_ml, stratify_labels=y_ml, for_dl=False # for_dl=False for sklearn
+    # 4. Process features for the training set (with augmentation)
+    print("\nProcessing features for training set (with augmentation)...")
+    train_features_df = feature_extractor.process_features_for_all_audio(
+        list(train_segments), list(train_labels), feature_type="stats_cell5", augment=True
     )
-    print(f"X_train_scaled shape: {X_train_scaled.shape}, y_train shape: {y_train.shape}")
-    print(f"X_test_scaled shape: {X_test_scaled.shape}, y_test shape: {y_test.shape}")
+    X_train_features = np.array(train_features_df['feature'].tolist())
+    y_train = np.array(train_features_df['class'].tolist()) # y_train_labels_numeric
     
-    # 6. Get and Train Model
+    if X_train_features.size == 0:
+        print("No features extracted for the training set. Exiting.")
+        return
+    print(f"Shape of X_train_features: {X_train_features.shape}")
+    print(f"Shape of y_train: {y_train.shape}")
+
+    # 5. Process features for the test set (WITHOUT augmentation)
+    print("\nProcessing features for test set (without augmentation)...")
+    test_features_df = feature_extractor.process_features_for_all_audio(
+        list(test_segments), list(test_labels), feature_type="stats_cell5", augment=False
+    )
+    X_test_features = np.array(test_features_df['feature'].tolist())
+    y_test = np.array(test_features_df['class'].tolist()) # y_test_labels_numeric
+
+    if X_test_features.size == 0:
+        print("No features extracted for the test set. Exiting.")
+        return
+    print(f"Shape of X_test_features: {X_test_features.shape}")
+    print(f"Shape of y_test: {y_test.shape}")
+    
+    num_features_extracted = X_train_features.shape[1]
+    print(f"\nNumber of features extracted: {num_features_extracted}")
+
+    # 6. Scale features
+    # Initialize a StandardScaler
+    # Fit the scaler ONLY on X_train_features and transform both
+    print("\nScaling features...")
+    scaler = StandardScaler()
+    X_train_scaled = scaler.fit_transform(X_train_features)
+    X_test_scaled = scaler.transform(X_test_features) # Apply the same transformation to the test set
+    
+    print(f"X_train_scaled shape: {X_train_scaled.shape}")
+    print(f"X_test_scaled shape: {X_test_scaled.shape}")
+    
+    # 7. Get and Train Model
     rf_model = models.get_rf_classifier()
     trained_rf_model = train_utils.train_sklearn_model(rf_model, X_train_scaled, y_train)
 
-    # 7. Evaluate
+    # 8. Evaluate
     evaluate_utils.evaluate_model_performance(
-        trained_rf_model, X_test_scaled, y_test, 
-        model_name="Random Forest (Combined Stats + Augmentation)", 
+        trained_rf_model, X_test_scaled, y_test,
+        model_name="Random Forest (Combined Stats + Augmentation, Split Before Aug)",
         is_keras_model=False
     )
 


### PR DESCRIPTION
The previous implementation of the machine learning pipeline with data augmentation (`src/main_ml_augmented.py`) had a potential data leakage issue. Augmentation was applied to the entire dataset *before* the train/test split. This could lead to augmented versions of samples effectively appearing in both the training and testing sets, resulting in overly optimistic performance metrics.

This commit refactors `src/main_ml_augmented.py` to:
1. Perform the train/test split on the raw audio segments and labels *before* any feature extraction or augmentation.
2. Apply data augmentation (via `feature_extractor.process_features_for_all_audio` with `augment=True`) *only* to the training segments.
3. Process features for the test segments *without* augmentation (`augment=False`).
4. Ensure that the `StandardScaler` is fitted *only* on the training features and then used to transform both training and test features.

These changes ensure that the test set remains truly unseen during the augmentation and feature scaling processes, providing a more reliable evaluation of the model's generalization performance. The model name in the evaluation output has also been updated to reflect this corrected methodology.